### PR TITLE
Replace prints with logging

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 import uvicorn
 from fastapi import FastAPI, Request
+import logging
 from aiogram import types
 from app.bot import bot, dp
 from app.config import settings
@@ -8,41 +9,43 @@ from contextlib import asynccontextmanager
 from app.keyboards.main_menu import set_main_menu
 from app.database.database import close_http_client
 
+logger = logging.getLogger(__name__)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     try:
         await set_main_menu(bot)
         await bot.set_webhook(settings.webhook_url, allowed_updates=["message", "callback_query"])
-        print("Webhook установлен успешно")
+        logger.info("Webhook установлен успешно")
         yield
     except Exception as e:
-        print(f"Ошибка при запуске приложения: {e}")
+        logger.exception("Ошибка при запуске приложения: %s", e)
         raise
     finally:
         try:
             await bot.delete_webhook()
-            print("Webhook удален")
+            logger.info("Webhook удален")
         except Exception as e:
-            print(f"Ошибка при удалении webhook: {e}")
+            logger.exception("Ошибка при удалении webhook: %s", e)
         
         try:
             await bot.session.close()
-            print("Bot session закрыт")
+            logger.info("Bot session закрыт")
         except Exception as e:
-            print(f"Ошибка при закрытии bot session: {e}")
+            logger.exception("Ошибка при закрытии bot session: %s", e)
         
         try:
             await dp.storage.close()
-            print("Storage закрыт")
+            logger.info("Storage закрыт")
         except Exception as e:
-            print(f"Ошибка при закрытии storage: {e}")
+            logger.exception("Ошибка при закрытии storage: %s", e)
         
         try:
             await close_http_client()
-            print("HTTP клиент закрыт")
+            logger.info("HTTP клиент закрыт")
         except Exception as e:
-            print(f"Ошибка при закрытии HTTP клиента: {e}")
+            logger.exception("Ошибка при закрытии HTTP клиента: %s", e)
 
 app = FastAPI(lifespan=lifespan, docs_url=None, redoc_url=None)
 
@@ -55,7 +58,7 @@ async def webhook(request: Request):
         await dp.feed_webhook_update(bot=bot, update=update)
         return {"status": "ok"}
     except Exception as e:
-        print(f"Ошибка при обработке webhook: {e}")
+        logger.exception("Ошибка при обработке webhook: %s", e)
         return {"status": "error", "message": str(e)}
 
 

--- a/app/services/log_handlers.py
+++ b/app/services/log_handlers.py
@@ -3,6 +3,8 @@ import asyncio
 import httpx
 from app.config import settings
 
+logger = logging.getLogger(__name__)
+
 
 class TelegramLogsHandler(logging.Handler):
     def emit(self, record):
@@ -16,7 +18,7 @@ class TelegramLogsHandler(logging.Handler):
             
             asyncio.create_task(self._send_log_async(update_id, log_entry))
         except Exception as e:
-            print(f"Ошибка в TelegramLogsHandler: {e}")
+            logger.exception("Ошибка в TelegramLogsHandler: %s", e)
 
     async def _send_log_async(self, chat_id: str, message: str):
         """Асинхронная отправка сообщения в Telegram"""
@@ -32,12 +34,18 @@ class TelegramLogsHandler(logging.Handler):
                 response = await client.post(url, data=data)
                 
                 if response.status_code != 200:
-                    print(f"Ошибка отправки лога в Telegram: {response.status_code} - {response.text}")
+                    logger.error(
+                        "Ошибка отправки лога в Telegram: %s - %s",
+                        response.status_code,
+                        response.text,
+                    )
                     
         except asyncio.TimeoutError:
-            print("Таймаут при отправке лога в Telegram")
+            logger.error("Таймаут при отправке лога в Telegram")
         except Exception as e:
-            print(f"Неожиданная ошибка при отправке лога в Telegram: {e}")
+            logger.exception(
+                "Неожиданная ошибка при отправке лога в Telegram: %s", e
+            )
 
 
 class SafeTelegramLogsHandler(logging.Handler):
@@ -63,9 +71,12 @@ class SafeTelegramLogsHandler(logging.Handler):
                 response = client.post(url, data=data)
                 
                 if response.status_code != 200:
-                    print(f"Ошибка отправки лога в Telegram: {response.status_code}")
+                    logger.error(
+                        "Ошибка отправки лога в Telegram: %s",
+                        response.status_code,
+                    )
                     
         except httpx.TimeoutException:
-            print("Таймаут при отправке лога в Telegram")
+            logger.error("Таймаут при отправке лога в Telegram")
         except Exception as e:
-            print(f"Ошибка в TelegramLogsHandler: {e}")
+            logger.exception("Ошибка в TelegramLogsHandler: %s", e)


### PR DESCRIPTION
## Summary
- add module level loggers
- use `logger.info`, `logger.error`, and `logger.exception` instead of `print`

## Testing
- `python -m py_compile app/main.py app/services/log_handlers.py`

------
https://chatgpt.com/codex/tasks/task_e_688764f9ecc48328bba95e57c71bf281