### PR TITLE
Add Redis credentials from environment

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,6 @@
 import os
+from typing import Optional
+
 from dotenv import load_dotenv
 from pydantic import HttpUrl, BaseSettings
 import logging
@@ -19,6 +21,8 @@ class Settings(BaseSettings):
     webhook_path: str = f"/{bot_token}"
     redis_host: str = "localhost"
     redis_port: int = 6379
+    redis_username: Optional[str] = os.getenv('REDIS_USERNAME')
+    redis_password: Optional[str] = os.getenv('REDIS_PASSWORD')
     soft_collection_user_code: str = "SoftCollect"
     constant_comment_id: int = 2
     delete_message_timer: int = 2

--- a/app/services/redis_data.py
+++ b/app/services/redis_data.py
@@ -2,7 +2,15 @@ import redis
 
 from redis.commands.json.path import Path
 
-r = redis.Redis(host='localhost', port=6379, decode_responses=True)
+from app.config import settings
+
+r = redis.Redis(
+    host=settings.redis_host,
+    port=settings.redis_port,
+    username=settings.redis_username,
+    password=settings.redis_password,
+    decode_responses=True,
+)
 
 
 def save_to_redis(task_id, data):


### PR DESCRIPTION
## Summary
- load Redis username and password from environment variables
- use credentials when creating Redis client

## Testing
- `pytest >/tmp/pytest.log || true`
- `tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689d981a018483289987040f672b6121